### PR TITLE
DTSPO-5507 - 'Hello World!' instead of 'Default Page Template' heading, tests changed to reflect change

### DIFF
--- a/src/main/views/home.njk
+++ b/src/main/views/home.njk
@@ -2,5 +2,5 @@
 {% extends "template.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Default page template</h1>
+  <h1 class="govuk-heading-xl">Hello World!</h1>
 {% endblock %}

--- a/src/test/functional/features/hello-world.feature
+++ b/src/test/functional/features/hello-world.feature
@@ -2,4 +2,4 @@ Feature: Initial Functional test
 
     Scenario: The home page loads
         When I go to '/'
-        Then the page should include 'Default page template'
+        Then the page should include 'Hello World!'

--- a/src/test/smoke/smoke.ts
+++ b/src/test/smoke/smoke.ts
@@ -14,7 +14,7 @@ describe('Smoke Test', () => {
             'Accept-Encoding': 'gzip',
           },
         });
-        expect(response.data).includes('<h1 class="govuk-heading-xl">Default page template</h1>');
+        expect(response.data).includes('<h1 class="govuk-heading-xl">Hello World!</h1>');
       } catch {
         fail('Heading not present and/or correct');
       }


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-5507


### Change description ###
'Hello World!' instead of 'Default Page Template' heading, tests changed to reflect change


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
